### PR TITLE
Move inline code snippets to F# script files and do line range embeds

### DIFF
--- a/docs/fsharp/using-fsharp-on-azure/index.md
+++ b/docs/fsharp/using-fsharp-on-azure/index.md
@@ -19,9 +19,7 @@ F# is a superb language for cloud programming and is frequently used to write we
 
 In the sections below, you will find resources on how to use a range of Azure services with F#.
 
-> Note: If a particular Azure service doesn't have documentation below, please consult the C# documentation for that service. Some
-> Azure services are entirely language-independent systems services and require no language-specific documentation, and in this
-> case are not listed here.
+> [!NOTE] If a particular Azure service doesn't have documentation below, please consult the C# documentation for that service. Some Azure services are entirely language-independent systems services and require no language-specific documentation, and in this case are not listed here.
 
 ## Using Azure Storage with F#
 

--- a/docs/fsharp/using-fsharp-on-azure/using-fsharp-on-azure-service-fabric.md
+++ b/docs/fsharp/using-fsharp-on-azure/using-fsharp-on-azure-service-fabric.md
@@ -1,4 +1,3 @@
 # Using F# on Azure Service Fabric
 
-> [!NOTE]
-This is still in progress.
+> [!NOTE] This is still in progress.

--- a/samples/snippets/fsharp/azure/blob-storage.fsx
+++ b/samples/snippets/fsharp/azure/blob-storage.fsx
@@ -1,0 +1,203 @@
+open System
+open System.IO
+open Microsoft.Azure // Namespace for CloudConfigurationManager
+open Microsoft.WindowsAzure.Storage // Namespace for CloudStorageAccount
+open Microsoft.WindowsAzure.Storage.Blob // Namespace for Blob storage types
+
+//
+// Get your connection string.
+//
+
+let storageConnString = "..." // fill this in from your storage account
+
+// Parse the connection string and return a reference to the storage account.
+let storageConnString = 
+    CloudConfigurationManager.GetSetting("StorageConnectionString")
+
+//
+// Parse the connection string.
+//
+
+// Parse the connection string and return a reference to the storage account.
+let storageAccount = CloudStorageAccount.Parse(storageConnString)
+
+//
+// Create some local dummy data.
+//
+
+// Create a dummy file in a local subdirectory to upload
+let localFile = __SOURCE_DIRECTORY__ + "/myfile.txt"
+File.WriteAllText(localFile, "some data")
+
+//
+// Create the blob service client.
+//
+
+let blobClient = storageAccount.CreateCloudBlobClient()
+
+//
+// Create a container.
+//
+
+ // Retrieve a reference to a container.
+let container = blobClient.GetContainerReference("mydata")
+
+// Create the container if it doesn't already exist.
+container.CreateIfNotExists()
+
+let permissions = BlobContainerPermissions(PublicAccess=BlobContainerPublicAccessType.Blob)
+container.SetPermissions(permissions)
+
+//
+// Upload a blob into a container.
+//
+
+// Retrieve reference to a blob named "myblob.txt".
+let blockBlob = container.GetBlockBlobReference("myblob.txt")
+
+// Create or overwrite the "myblob.txt" blob with contents from the local file.
+do
+    use fileStream = File.OpenRead localFile
+    blockBlob.UploadFromStream(fileStream)
+
+//
+// List the blobs in a container.
+//
+
+// Loop over items within the container and output the length and URI.
+for item in container.ListBlobs(null, false) do
+    match item with 
+    | :? CloudBlockBlob as blob -> 
+        printfn "Block blob of length %d: %O" blob.Properties.Length blob.Uri
+
+    | :? CloudPageBlob as pageBlob ->
+        printfn "Page blob of length %d: %O" pageBlob.Properties.Length pageBlob.Uri
+
+    | :? CloudBlobDirectory as directory ->
+        printfn "Directory: %O" directory.Uri
+
+    | _ ->
+        printfn "Unknown blob type: %O" (item.GetType())
+
+// Loop over items within the container and output the length and URI.
+for item in container.ListBlobs(null, true) do
+    match item with 
+    | :? CloudBlockBlob as blob -> 
+        printfn "Block blob of length %d: %O" blob.Properties.Length blob.Uri
+
+    | _ ->
+        printfn "Unexpected blob type: %O" (item.GetType())
+
+//
+// Download Blobs.
+//
+
+// Retrieve reference to a blob named "myblob.txt".
+let blobToDownload = container.GetBlockBlobReference("myblob.txt")
+
+// Save blob contents to a file.
+do
+    use fileStream = File.OpenWrite(__SOURCE_DIRECTORY__ + "/path/download.txt")
+    blobToDownload.DownloadToStream(fileStream)
+
+let text =
+    use memoryStream = new MemoryStream()
+    blobToDownload.DownloadToStream(memoryStream)
+    Text.Encoding.UTF8.GetString(memoryStream.ToArray())
+
+//
+// Delete blobs.
+//
+
+// Retrieve reference to a blob named "myblob.txt".
+let blobToDelete = container.GetBlockBlobReference("myblob.txt")
+
+// Delete the blob.
+blobToDelete.Delete()
+
+//
+// List blobs in pages asynchronously
+//
+
+let ListBlobsSegmentedInFlatListing(container:CloudBlobContainer) =
+    async {
+
+        // List blobs to the console window, with paging.
+        printfn "List blobs in pages:"
+
+        // Call ListBlobsSegmentedAsync and enumerate the result segment
+        // returned, while the continuation token is non-null.
+        // When the continuation token is null, the last page has been 
+        // returned and execution can exit the loop.
+
+        let rec loop continuationToken (i:int) = 
+            async {
+                // This overload allows control of the page size. You can return
+                // all remaining results by passing null for the maxResults 
+                // parameter, or by calling a different overload.
+                let! ct = Async.CancellationToken
+                let! resultSegment = 
+                    container.ListBlobsSegmentedAsync(
+                        "", true, BlobListingDetails.All, Nullable 10, 
+                        continuationToken, null, null, ct) 
+                    |> Async.AwaitTask
+
+                if (resultSegment.Results |> Seq.length > 0) then
+                    printfn "Page %d:" i
+
+                for blobItem in resultSegment.Results do
+                    printfn "\t%O" blobItem.StorageUri.PrimaryUri
+
+                printfn ""
+
+                // Get the continuation token.
+                let continuationToken = resultSegment.ContinuationToken
+                if (continuationToken <> null) then
+                    do! loop continuationToken (i+1)
+            }
+    
+        do! loop null 1
+    }
+
+// Create some dummy data by upoading the same file over andd over again
+for i in 1 .. 100 do
+    let blob  = container.GetBlockBlobReference("myblob" + string i + ".txt")
+    use fileStream = System.IO.File.OpenRead(localFile)
+    blob.UploadFromStream fileStream
+
+ListBlobsSegmentedInFlatListing container |> Async.RunSynchronously
+
+//
+// Writing to an append blob.
+//
+
+// Get a reference to a container.
+let appendContainer = blobClient.GetContainerReference("my-append-blobs")
+
+// Create the container if it does not already exist.
+appendContainer.CreateIfNotExists() |> ignore
+
+// Get a reference to an append blob.
+let appendBlob = appendContainer.GetAppendBlobReference("append-blob.log")
+
+// Create the append blob. Note that if the blob already exists, the 
+// CreateOrReplace() method will overwrite it. You can check whether the 
+// blob exists to avoid overwriting it by using CloudAppendBlob.Exists().
+appendBlob.CreateOrReplace()
+
+let numBlocks = 10
+
+// Generate an array of random bytes.
+let rnd = new Random()
+let bytes = Array.zeroCreate<byte>(numBlocks)
+rnd.NextBytes(bytes)
+
+// Simulate a logging operation by writing text data and byte data to the 
+// end of the append blob.
+for i in 0 .. numBlocks - 1 do
+    let msg = sprintf "Timestamp: %u \tLog Entry: %d\n" DateTime.UtcNow bytes.[i]
+    appendBlob.AppendText(msg)
+
+// Read the append blob to the console window.
+let downloadedText = appendBlob.DownloadText()
+printfn "%s" downloadedText

--- a/samples/snippets/fsharp/azure/file-storage.fsx
+++ b/samples/snippets/fsharp/azure/file-storage.fsx
@@ -1,0 +1,131 @@
+open System
+open System.IO
+open Microsoft.Azure // Namespace for CloudConfigurationManager
+open Microsoft.WindowsAzure.Storage // Namespace for CloudStorageAccount
+open Microsoft.WindowsAzure.Storage.File // Namespace for File storage types
+
+//
+// Get your connection string.
+//
+
+let storageConnString = "..." // fill this in from your storage account
+
+// Parse the connection string and return a reference to the storage account.
+let storageConnString = 
+    CloudConfigurationManager.GetSetting("StorageConnectionString")
+
+//
+// Parse the connection string.
+//
+
+// Parse the connection string and return a reference to the storage account.
+let storageAccount = CloudStorageAccount.Parse(storageConnString)
+
+//
+// Create the File service client.
+//
+
+let fileClient = storageAccount.CreateCloudFileClient()
+
+//
+// Create a file share.
+//
+
+let share = fileClient.GetShareReference("myFiles")
+share.CreateIfNotExists()
+
+//
+// Access the file share programmatically.
+//
+
+let rootDir = share.GetRootDirectoryReference()
+let subDir = rootDir.GetDirectoryReference("myLogs")
+
+if subDir.Exists() then
+    let file = subDir.GetFileReference("log.txt")
+    if file.Exists() then
+        file.DownloadToFile("log.txt", FileMode.Append)
+
+//
+// Set the maximum size for a file share.
+//
+
+// stats.Usage is current usage in GB
+let stats = share.GetStats()
+share.FetchAttributes()
+
+// Set the quota to 10 GB plus current usage
+share.Properties.Quota <- stats.Usage + 10 |> Nullable
+share.SetProperties()
+
+// Remove the quota
+share.Properties.Quota <- Nullable()
+share.SetProperties()
+
+//
+// Generate a shared access signature for a file or file share.
+//
+
+// Create a 24 hour read/write policy.
+let policy = SharedAccessFilePolicy()
+policy.SharedAccessExpiryTime <- 
+    DateTimeOffset.UtcNow.AddHours(24.) |> Nullable
+policy.Permissions <- 
+    SharedAccessFilePermissions.Read ||| SharedAccessFilePermissions.Write
+
+// Set the policy on the share.
+let permissions = share.GetPermissions()
+permissions.SharedAccessPolicies.Add("policyName", policy)
+share.SetPermissions(permissions)
+
+let file = subDir.GetFileReference("log.txt")
+let sasToken = file.GetSharedAccessSignature(policy)
+let sasUri = Uri(file.StorageUri.PrimaryUri.ToString() + sasToken)
+
+let fileSas = CloudFile(sasUri)
+fileSas.UploadText("This write operation is authenticated via SAS")
+
+//
+// Copy a file to another file.
+//
+
+let destFile = subDir.GetFileReference("log_copy.txt")
+destFile.StartCopy(file)
+
+//
+// Copy a file to a blob.
+//
+
+// Get a reference to the blob to which the file will be copied.
+let blobClient = storageAccount.CreateCloudBlobClient()
+let container = blobClient.GetContainerReference("myContainer")
+container.CreateIfNotExists()
+let destBlob = container.GetBlockBlobReference("log_blob.txt")
+
+let filePolicy = SharedAccessFilePolicy()
+filePolicy.Permissions <- SharedAccessFilePermissions.Read
+filePolicy.SharedAccessExpiryTime <- 
+    DateTimeOffset.UtcNow.AddHours(24.) |> Nullable
+
+let fileSas2 = file.GetSharedAccessSignature(filePolicy)
+let sasUri2 = Uri(file.StorageUri.PrimaryUri.ToString() + fileSas2)
+destBlob.StartCopy(sasUri2)
+
+//
+// Troubleshooting File storage using metrics.
+//
+
+open Microsoft.WindowsAzure.Storage.File.Protocol
+open Microsoft.WindowsAzure.Storage.Shared.Protocol
+
+let props = FileServiceProperties()
+props.HourMetrics <- MetricsProperties()
+props.HourMetrics.MetricsLevel <- MetricsLevel.ServiceAndApi
+props.HourMetrics.RetentionDays <- 14 |> Nullable
+props.HourMetrics.Version <- "1.0"
+props.MinuteMetrics <- MetricsProperties()
+props.MinuteMetrics.MetricsLevel <- MetricsLevel.ServiceAndApi
+props.MinuteMetrics.RetentionDays <- 7 |> Nullable
+props.MinuteMetrics.Version <- "1.0"
+
+fileClient.SetServiceProperties(props)

--- a/samples/snippets/fsharp/azure/queue-storage.fsx
+++ b/samples/snippets/fsharp/azure/queue-storage.fsx
@@ -1,0 +1,103 @@
+open Microsoft.Azure // Namespace for CloudConfigurationManager 
+open Microsoft.WindowsAzure.Storage // Namespace for CloudStorageAccount
+open Microsoft.WindowsAzure.Storage.Queue // Namespace for Queue storage types
+
+//
+// Get your connection string.
+//
+
+let storageConnString = "..." // fill this in from your storage account
+
+// Parse the connection string and return a reference to the storage account.
+let storageConnString = 
+    CloudConfigurationManager.GetSetting("StorageConnectionString")
+
+//
+// Parse the connection string.
+//
+
+// Parse the connection string and return a reference to the storage account.
+let storageAccount = CloudStorageAccount.Parse(storageConnString)
+
+//
+// Create the Queue Service client.
+//
+
+let queueClient = storageAccount.CreateCloudQueueClient()
+
+//
+// Create a queue.
+//
+
+// Retrieve a reference to a container.
+let queue = queueClient.GetQueueReference("myqueue")
+
+// Create the queue if it doesn't already exist
+queue.CreateIfNotExists()
+
+//
+// Insert a message into a queue.
+//
+
+// Create a message and add it to the queue.
+let message = new CloudQueueMessage("Hello, World")
+queue.AddMessage(message)
+
+//
+// Peek at the next message.
+//
+
+// Peek at the next message.
+let peekedMessage = queue.PeekMessage()
+let msgAsString = peekedMessage.AsString
+
+//
+// Change the contents of a queued message.
+//
+
+// Update the message contents and set a new timeout.
+message.SetMessageContent("Updated contents.")
+queue.UpdateMessage(message,
+    TimeSpan.FromSeconds(60.0),
+    MessageUpdateFields.Content ||| MessageUpdateFields.Visibility)
+
+//
+// De-queue the next message.
+//
+
+// Process the message in less than 30 seconds, and then delete the message.
+queue.DeleteMessage(message)
+
+//
+// Use Async-Await pattern with common Queue storage APIs.
+//
+
+async {
+    let! exists = queue.CreateIfNotExistsAsync() |> Async.AwaitTask
+    let msg = new CloudQueueMessage("My message")
+    queue.AddMessageAsync(msg) |> Async.AwaitTask
+    let! retrieved = queue.GetMessageAsync() |> Async.AwaitTask
+    queue.DeleteMessageAsync(retrieved) |> Async.AwaitTask
+}
+
+//
+// Additional options for de-queuing messages.
+//
+
+for msg in queue.GetMessages(20, Nullable(TimeSpan.FromMinutes(5.))) do
+        // Process the message here.
+        queue.DeleteMessage(msg)
+
+//
+// Get the queue length.
+//
+
+queue.FetchAttributes()
+let count = queue.ApproximateMessageCount.GetValueOrDefault()
+
+//
+// Delete a queue.
+//
+
+// Delete the queue.
+queue.Delete()

--- a/samples/snippets/fsharp/azure/table-storage.fsx
+++ b/samples/snippets/fsharp/azure/table-storage.fsx
@@ -1,0 +1,174 @@
+open System
+open System.IO
+open Microsoft.Azure // Namespace for CloudConfigurationManager
+open Microsoft.WindowsAzure.Storage // Namespace for CloudStorageAccount
+open Microsoft.WindowsAzure.Storage.Table // Namespace for Table storage types
+
+//
+// Get your connection string.
+//
+
+let storageConnString = "..." // fill this in from your storage account
+
+// Parse the connection string and return a reference to the storage account.
+let storageConnString = 
+    CloudConfigurationManager.GetSetting("StorageConnectionString")
+
+//
+// Parse the connection string.
+//
+
+// Parse the connection string and return a reference to the storage account.
+let storageAccount = CloudStorageAccount.Parse(storageConnString)
+
+//
+// Create the Table service client.
+//
+
+// Create the table client.
+let tableClient = storageAccount.CreateCloudTableClient()
+
+//
+// Create a table.
+//
+
+// Retrieve a reference to the table.
+let table = tableClient.GetTableReference("people")
+
+// Create the table if it doesn't exist.
+table.CreateIfNotExists()
+
+//
+// Add an entity to a table.
+//
+
+type Customer
+    (firstName, lastName, email: string, phone: string) =
+    inherit TableEntity(lastName, firstName)
+    new() = Customer(null, null, null, null)
+    member val Email = email with get, set
+    member val PhoneNumber = phone with get, set
+
+let customer = 
+    Customer("Larry", "Buster", "larry@example.com", "425-555-0101")
+
+let insertOp = TableOperation.Insert(customer)
+table.Execute(insertOp)
+
+//
+// Insert a batch of entities.
+//
+
+let customer2 =
+    Customer("Bob", "Boomer", "bob@example.com", "425-555-0102")
+
+let batchOp = TableBatchOperation()
+batchOp.Insert(customer)
+batchOp.Insert(customer2)
+table.ExecuteBatch(batchOp)
+
+//
+// Retreive all entities in a partition.
+//
+
+let query =
+    TableQuery<Customer>().Where(
+        TableQuery.GenerateFilterCondition(
+            "PartitionKey", QueryComparisons.Equal, "Buster"))
+
+let result = table.ExecuteQuery(query)
+
+//
+// Retrieve a range of entities in a partition.
+//
+
+let range =
+    TableQuery<Customer>().Where(
+        TableQuery.CombineFilters(
+            TableQuery.GenerateFilterCondition(
+                "PartitionKey", QueryComparisons.Equal, "Buster"),
+            TableOperators.And,
+            TableQuery.GenerateFilterCondition(
+                "RowKey", QueryComparisons.LessThan, "M")))
+
+let rangeResult = table.ExecuteQuery(query)
+
+//
+// Retrieve a single entity.
+//
+
+let retrieveOp = TableOperation.Retrieve<Customer>("Buster", "Larry")
+let retrieveResult = table.Execute(retrieveOp)
+
+//
+// Replace an entity.
+//
+
+try
+    let customer = retrieveResult.Result :?> Customer
+    customer.PhoneNumber <- "425-555-0103"
+    let replaceOp = TableOperation.Replace(customer)
+    table.Execute(replaceOp) |> ignore
+with e ->
+    Console.WriteLine("Update failed")
+
+//
+// Insert-or-update an entity.
+//
+
+try
+    customer.PhoneNumber <- "425-555-0104"
+    let replaceOp = TableOperation.InsertOrReplace(customer)
+    table.Execute(replaceOp) |> ignore
+with e ->
+    Console.WriteLine("Update failed")
+
+//
+// Query a subset of entity properties.
+//
+
+// Define the query, and select only the Email property.
+let projectionQ = TableQuery<DynamicTableEntity>().Select([|"Email"|])
+
+// Define an entity resolver to work with the entity after retrieval.
+let resolver = EntityResolver<string>(fun pk rk ts props etag ->
+    if props.ContainsKey("Email") then
+        props.["Email"].StringValue
+    else
+        null
+    )
+
+table.ExecuteQuery(projectionQ, resolver, null, null)
+
+//
+// Delete an entity.
+//
+
+let deleteOp = TableOperation.Delete(customer)
+table.Execute(deleteOp)
+
+//
+// Delete a table.
+//
+
+table.DeleteIfExists()
+
+//
+// Retrieve entities in pages asynchronously.
+//
+
+let tableQ = TableQuery<Customer>()
+
+async {
+    let rec q (cont: TableContinuationToken) = async {
+        let! result = 
+            table.ExecuteQuerySegmentedAsync(tableQ, cont) 
+            |> Async.AwaitTask
+
+        // Process the result here.
+        match result.ContinuationToken with
+        | null -> return ()
+        | cont -> q cont |> Async.RunSynchronously
+    }
+    q null |> Async.RunSynchronously
+} |> Async.RunSynchronously


### PR DESCRIPTION
Moved inline code snippets into F# script files that are in the `/samples` directory.

Right now they still won't compile, as they take a dependency on certain packages.  We might need to put the samples in an actual project with package references.
